### PR TITLE
Use version from $options if possible.

### DIFF
--- a/src/SepaUtilities.php
+++ b/src/SepaUtilities.php
@@ -648,6 +648,9 @@ class SepaUtilities
     public static function check($field, $input, array $options = null, $version = null)
     {
         $field = strtolower($field);
+        if ($version === null && isset($options['version'])) {
+            $version = $options['version'];
+        }
         switch($field)      // fall-through's are on purpose
         {
             case 'orgnlcdtrschmeid_id':


### PR DESCRIPTION
checkAndSanitize() and checkInput() dont handle $version as parameter.
Therefore, sephpa passes the version in $options like:
array('version' => .... )

Look here: https://github.com/AbcAeffchen/Sephpa/blob/master/src/payment-collections/SepaDirectDebit00800302.php#L81